### PR TITLE
Standardise test and linting execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "bot-scripts": "./bin/index.js"
   },
   "scripts": {
-    "test": "jest --env node --setupFilesAfterEnv ./scripts/test/mock-logger.js",
-    "lint": "eslint . --config=./scripts/lint/eslintrc.json"
+    "test": "node ./scripts/test",
+    "lint": "node ./scripts/lint ."
   },
   "dependencies": {
     "botkit": "^0.7.0",

--- a/scripts/lint/index.js
+++ b/scripts/lint/index.js
@@ -1,29 +1,16 @@
-process.on("unhandledRejection", function(err) {
-  throw err;
-});
-
 const path = require("path");
-const spawn = require("cross-spawn");
-const { getBotDirectory, getArgs } = require("../utils");
+const {
+  getBotDirectory,
+  getArgs,
+  startsWithPath,
+  setupScript
+} = require("../shared");
 
+const execute = setupScript("eslint");
 const botDirectory = getBotDirectory();
 const args = getArgs();
 const lintingFiles = path.resolve(botDirectory, "./src");
 const eslintConfig = path.resolve(__dirname, "./eslintrc.json");
-const eslint = path.resolve(
-  require.resolve("eslint").split("eslint")[0],
-  "./eslint/bin/eslint.js"
-);
 
-const result = spawn.sync(
-  eslint,
-  [lintingFiles, "--config", eslintConfig].concat(args),
-  { stdio: "inherit" }
-);
-
-if (result.error) {
-  console.error(result.error); // eslint-disable-line no-console
-  process.exit(1);
-}
-if (result.signal) process.exit(1);
-process.exit(result.status);
+const cwd = startsWithPath(args) ? args.shift() : lintingFiles;
+execute([cwd, "--config", eslintConfig].concat(args));

--- a/scripts/shared/__mocks__/test-tool.js
+++ b/scripts/shared/__mocks__/test-tool.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/scripts/shared/index.js
+++ b/scripts/shared/index.js
@@ -1,0 +1,35 @@
+const fs = require("fs");
+const path = require("path");
+const spawn = require("cross-spawn");
+
+const setupScript = function(tool) {
+  process.on("unhandledRejection", function(err) {
+    throw err;
+  });
+
+  const executable = path.resolve(
+    require.resolve(tool).split(tool)[0],
+    `./${tool}/bin/${tool}.js`
+  );
+
+  return function call(args) {
+    const result = spawn.sync(executable, args, { stdio: "inherit" });
+
+    if (result.error) {
+      console.error(result.error); // eslint-disable-line no-console
+      process.exit(1);
+    }
+    if (result.signal) process.exit(1);
+    process.exit(result.status);
+  };
+};
+
+module.exports = {
+  getArgs: () => process.argv.slice(2),
+  getBotDirectory: () => fs.realpathSync(process.cwd()),
+  startsWithPath: args =>
+    typeof args[0] === "string" &&
+    args[0].trim().length > 0 &&
+    !args[0].trim().startsWith("--"),
+  setupScript
+};

--- a/scripts/shared/tests/index.spec.js
+++ b/scripts/shared/tests/index.spec.js
@@ -1,0 +1,135 @@
+global.process.on = jest.fn();
+global.process.exit = jest.fn();
+console.error = jest.fn(); // eslint-disable-line no-console
+
+const mockSpawnSync = jest.fn();
+jest.mock("cross-spawn", () => ({ sync: mockSpawnSync }));
+jest.mock("test-tool");
+
+const {
+  getArgs,
+  getBotDirectory,
+  startsWithPath,
+  setupScript
+} = require("../");
+
+describe("shared task utils", function() {
+  let testContext;
+
+  beforeEach(function() {
+    jest.clearAllMocks();
+    jest.resetModules();
+    testContext = {};
+  });
+
+  describe("getArgs", function() {
+    beforeEach(function() {
+      global.process.argv = ["node-process", "file-path", "hello", "world"];
+    });
+
+    it("returns list of arguments", function() {
+      expect(getArgs()).toEqual(["hello", "world"]);
+    });
+  });
+
+  describe("getBotDirectory", function() {
+    it("returns bot directory", function() {
+      expect(getBotDirectory()).toEqual(
+        expect.stringMatching(/\/bot-scripts$/)
+      );
+    });
+  });
+
+  describe("startsWithPath", function() {
+    describe("empty arguments", function() {
+      beforeEach(function() {
+        testContext.args = [];
+      });
+
+      it("returns false", function() {
+        expect(startsWithPath(testContext.args)).toBe(false);
+      });
+    });
+
+    describe("flag arguments", function() {
+      beforeEach(function() {
+        testContext.args = ["--watch", "--fix"];
+      });
+
+      it("returns false", function() {
+        expect(startsWithPath(testContext.args)).toBe(false);
+      });
+    });
+
+    describe("arguments with leading path", function() {
+      beforeEach(function() {
+        testContext.args = ["/path/to/file", "--fix"];
+      });
+
+      it("returns true", function() {
+        expect(startsWithPath(testContext.args)).toBe(true);
+      });
+    });
+
+    describe("arguments which include path", function() {
+      beforeEach(function() {
+        testContext.args = ["--watch", "/path/to/file ", "--fix"];
+      });
+
+      it("returns true", function() {
+        expect(startsWithPath(testContext.args)).toBe(false);
+      });
+    });
+  });
+
+  describe("setupScript", function() {
+    beforeEach(function() {
+      testContext.scriptExecutor = setupScript("test-tool");
+    });
+
+    describe("script success", function() {
+      beforeEach(function() {
+        mockSpawnSync.mockReturnValue({ status: 0 });
+        testContext.scriptExecutor(["foo"]);
+      });
+
+      it("calls eslint with the correct arguments", function() {
+        expect(mockSpawnSync.mock.calls.length).toBe(1);
+        expect(mockSpawnSync.mock.calls[0]).toEqual([
+          expect.stringContaining("/test-tool/bin/test-tool.js"),
+          ["foo"],
+          { stdio: "inherit" }
+        ]);
+      });
+
+      it("exits with success", function() {
+        expect(process.exit.mock.calls.length).toBe(1);
+        expect(process.exit).toHaveBeenCalledWith(0);
+      });
+    });
+
+    describe("script interupted", function() {
+      beforeEach(function() {
+        mockSpawnSync.mockReturnValue({ signal: true });
+        testContext.scriptExecutor(["foo"]);
+      });
+
+      it("exits with failure", function() {
+        expect(process.exit.mock.calls.length).toBe(2);
+        expect(process.exit).toHaveBeenCalledWith(1);
+      });
+    });
+
+    describe("script error", function() {
+      beforeEach(function() {
+        mockSpawnSync.mockReturnValue({ error: true });
+        testContext.scriptExecutor(["foo"]);
+      });
+
+      it("exits with failure", function() {
+        expect(process.exit.mock.calls.length).toBe(2);
+        expect(process.exit).toHaveBeenCalledWith(1);
+      });
+    });
+  });
+});

--- a/scripts/start/index.js
+++ b/scripts/start/index.js
@@ -3,7 +3,7 @@ process.on("unhandledRejection", function(err) {
 });
 
 const path = require("path");
-const { getBotDirectory } = require("../utils");
+const { getBotDirectory } = require("../shared");
 const botDirectory = getBotDirectory();
 
 const botPath = path.resolve(botDirectory, "./src/index.js");

--- a/scripts/test/index.js
+++ b/scripts/test/index.js
@@ -1,20 +1,17 @@
-process.on("unhandledRejection", function(err) {
-  throw err;
-});
-
 const path = require("path");
-const jest = require("jest");
-const { getBotDirectory, getArgs } = require("../utils");
+const {
+  getBotDirectory,
+  getArgs,
+  startsWithPath,
+  setupScript
+} = require("../shared");
 
+const execute = setupScript("jest");
 const botDirectory = getBotDirectory();
 const args = getArgs();
 const mockLogger = path.resolve(__dirname, "./mock-logger.js");
-jest.run(
-  [botDirectory].concat(
-    args,
-    "--env",
-    "node",
-    "--setupFilesAfterEnv",
-    mockLogger
-  )
+
+const cwd = startsWithPath(args) ? args.shift() : botDirectory;
+execute(
+  [cwd, "--env", "node", "--setupFilesAfterEnv", mockLogger].concat(args)
 );

--- a/scripts/test/tests/index.spec.js
+++ b/scripts/test/tests/index.spec.js
@@ -9,7 +9,7 @@ jest.mock("../../shared", () =>
   })
 );
 
-describe("lint script", function() {
+describe("test script", function() {
   beforeEach(function() {
     jest.clearAllMocks();
     jest.resetModules();
@@ -21,13 +21,15 @@ describe("lint script", function() {
       require("../"); // eslint-disable-line global-require
     });
 
-    it("calls eslint with the correct arguments", function() {
+    it("calls jest with the correct arguments", function() {
       expect(mockSetupScript.mock.calls.length).toBe(1);
       expect(mockSetupScript.mock.calls[0]).toEqual([
         [
-          expect.stringContaining("/bot-scripts/foo/src"),
-          "--config",
-          expect.stringContaining("/bot-scripts/scripts/lint/eslintrc.json")
+          "foo",
+          "--env",
+          "node",
+          "--setupFilesAfterEnv",
+          expect.stringContaining("/bot-scripts/scripts/test/mock-logger.js")
         ]
       ]);
     });
@@ -35,18 +37,20 @@ describe("lint script", function() {
 
   describe("when additional flag argument passed", function() {
     beforeEach(function() {
-      mockGetArgs.mockReturnValue(["--fix"]);
+      mockGetArgs.mockReturnValue(["--watch"]);
       require("../"); // eslint-disable-line global-require
     });
 
-    it("calls eslint with the correct arguments", function() {
+    it("calls jest with the correct arguments", function() {
       expect(mockSetupScript.mock.calls.length).toBe(1);
       expect(mockSetupScript.mock.calls[0]).toEqual([
         [
-          expect.stringContaining("/bot-scripts/foo/src"),
-          "--config",
-          expect.stringContaining("/bot-scripts/scripts/lint/eslintrc.json"),
-          "--fix"
+          "foo",
+          "--env",
+          "node",
+          "--setupFilesAfterEnv",
+          expect.stringContaining("/bot-scripts/scripts/test/mock-logger.js"),
+          "--watch"
         ]
       ]);
     });
@@ -54,17 +58,19 @@ describe("lint script", function() {
 
   describe("when path argument passed", function() {
     beforeEach(function() {
-      mockGetArgs.mockReturnValue(["/new/lint/path"]);
+      mockGetArgs.mockReturnValue(["/new/test/path"]);
       require("../"); // eslint-disable-line global-require
     });
 
-    it("calls eslint with the correct arguments", function() {
+    it("calls jest with the correct arguments", function() {
       expect(mockSetupScript.mock.calls.length).toBe(1);
       expect(mockSetupScript.mock.calls[0]).toEqual([
         [
-          "/new/lint/path",
-          "--config",
-          expect.stringContaining("/bot-scripts/scripts/lint/eslintrc.json")
+          "/new/test/path",
+          "--env",
+          "node",
+          "--setupFilesAfterEnv",
+          expect.stringContaining("/bot-scripts/scripts/test/mock-logger.js")
         ]
       ]);
     });
@@ -72,18 +78,20 @@ describe("lint script", function() {
 
   describe("when mixture of arguments passed", function() {
     beforeEach(function() {
-      mockGetArgs.mockReturnValue(["/new/lint/path", "--fix"]);
+      mockGetArgs.mockReturnValue(["/new/test/path", "--watch"]);
       require("../"); // eslint-disable-line global-require
     });
 
-    it("calls eslint with the correct arguments", function() {
+    it("calls jest with the correct arguments", function() {
       expect(mockSetupScript.mock.calls.length).toBe(1);
       expect(mockSetupScript.mock.calls[0]).toEqual([
         [
-          "/new/lint/path",
-          "--config",
-          expect.stringContaining("/bot-scripts/scripts/lint/eslintrc.json"),
-          "--fix"
+          "/new/test/path",
+          "--env",
+          "node",
+          "--setupFilesAfterEnv",
+          expect.stringContaining("/bot-scripts/scripts/test/mock-logger.js"),
+          "--watch"
         ]
       ]);
     });

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,6 +1,0 @@
-const fs = require("fs");
-
-module.exports = {
-  getArgs: () => process.argv.slice(2),
-  getBotDirectory: () => fs.realpathSync(process.cwd())
-};


### PR DESCRIPTION
Move `bot-scripts` test and lint commands over to using the same runner as the test and lint commands used by bots which install `bot-scripts` as a dependency. This also standardises calls to `eslint` and `jest` by using the cli interface for both and proxying cli arguments through. Tests have been added for new shared functionality, as well as the test and lint command runners.